### PR TITLE
Improve highlights.scm

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -38,6 +38,7 @@
  "false"
  "and"
  "or"
+ "alias"
 ] @keyword
 
 [
@@ -59,3 +60,9 @@
  "," 
  ";" 
 ] @delimiter
+
+["[" "]" "{" "}"] @punctuation.bracket
+
+["(" ")"] @keyword.directive
+
+


### PR DESCRIPTION
Added "alias" to keywords, square and curly brackets as brackets, and  parentheses as keyword.directive for distinction.

The last one might be subject for discussion, I guess?